### PR TITLE
#6 - Fix memory leaks

### DIFF
--- a/include/compute.hpp
+++ b/include/compute.hpp
@@ -602,7 +602,8 @@ void H2_3D_Compute<T>::NearFieldInteractions(vector3 *target, vector3 *source,
         
         // Compute Sf, the mapping function for the target points
         FMMTree->ComputeSn(targett,Tkz,n,Nf,Sf, use_chebyshev);
-        
+        free(targett);
+        targett = NULL;
         // Compute the values at the field points
         for (int col=0; col<this->nCols; col++) {
 
@@ -623,6 +624,8 @@ void H2_3D_Compute<T>::NearFieldInteractions(vector3 *target, vector3 *source,
                 A->nodePhi[col*Nf+i] += sum;
             }
         }
+        free(Sf);
+        Sf = NULL;
     }
     
     #pragma omp parallel for private(leafAIndex)

--- a/src/H2_3D_Tree.cpp
+++ b/src/H2_3D_Tree.cpp
@@ -124,8 +124,10 @@ bool H2_3D_Tree::PrecomputeAvailable( char *Kmat, char *Umat, char *Vmat,
   if (fK!=NULL) fclose(fK);
   if (fU!=NULL) fclose(fU);
   if (fV!=NULL) fclose(fV);
-  if (avail) printf("Precompute files exist.\n");
-  else printf("Precompute files do NOT exist.\n");
+  if (avail)
+    cout <<"Precompute files exist.\n";
+  else
+    cout<<"Precompute files do NOT exist.\n";
   return avail;
 }
 


### PR DESCRIPTION
Hello,
There were some variables in the Codebase that actually missed to be cleared. This caused a buildup in memory, especially when used with PyBind11.

My PR frees these variables. Feel free to ping for updates.